### PR TITLE
Handle raw icon and cursor images

### DIFF
--- a/python_resource_editor/src/gui/main_window.py
+++ b/python_resource_editor/src/gui/main_window.py
@@ -18,6 +18,7 @@ from ..core.resource_base import Resource, ResourceIdentifier, FileResource, Tex
 from ..core.resource_types import StringTableResource, RCDataResource, MenuResource, DialogResource, VersionInfoResource, AcceleratorResource, get_resource_class # RCDataResource and get_resource_class are imported
 from ..utils.external_tools import run_windres_compile, WindresError, get_tool_path # Import get_tool_path
 from ..utils import image_utils
+from ..utils.image_utils import open_raw_icon_or_cursor
 from ..core.resource_base import (
     RT_CURSOR, RT_BITMAP, RT_ICON, RT_MENU, RT_DIALOG, RT_STRING, RT_FONTDIR,
     RT_FONT, RT_ACCELERATOR, RT_RCDATA, RT_MESSAGETABLE, RT_GROUP_CURSOR,
@@ -463,13 +464,14 @@ class App(customtkinter.CTk):
                                     actual_image_to_display = r_search
                                     if r_search.identifier.language_id == res_obj.identifier.language_id: # Exact lang match is best
                                         break
-
                         if actual_image_to_display and actual_image_to_display.data:
-                            try:
                                 img_data_member = io.BytesIO(actual_image_to_display.data)
-                                img = Image.open(img_data_member)
-
-                                # Apply ICO/CUR frame selection logic for the member image
+                                try:
+                                    img = Image.open(img_data_member)
+                                except UnidentifiedImageError:
+                                    img = open_raw_icon_or_cursor(actual_image_to_display.data, expected_member_type == RT_CURSOR)
+                                    if not img:
+                                        raise
                                 is_member_format_ico_or_cur = (getattr(img, "format", "").upper() in ["ICO", "CUR"])
 
                                 if is_member_format_ico_or_cur and getattr(img, "n_frames", 1) > 1:
@@ -538,14 +540,19 @@ class App(customtkinter.CTk):
                         img_data = io.BytesIO(res_obj.data)
 
                     if img_data:
-                        img = Image.open(img_data)
+                        try:
+                            img = Image.open(img_data)
+                        except UnidentifiedImageError:
+                            img = open_raw_icon_or_cursor(res_obj.data, res_obj.identifier.type_id == RT_CURSOR)
+                            if not img:
+                                raise
 
                         # ????????????????????????????
                         # Replace old ICO logic with combined RAW?RT_ICON / ICO?file check
                         is_raw_icon = (res_obj.identifier.type_id == RT_ICON)
                         is_ico_file = (getattr(img, "format", "").upper() == "ICO")
                         if is_raw_icon or is_ico_file:
-                            # If it?s a true .ico container with multiple frames, pick 32×32 or the largest
+                            # If it?s a true .ico container with multiple frames, pick 32Ã—32 or the largest
                             if is_ico_file and getattr(img, "n_frames", 1) > 1:
                                 target = (32, 32)
                                 best = None


### PR DESCRIPTION
## Summary
- add helper to open raw RT_ICON or RT_CURSOR data via a temporary ICO/CUR header
- fall back to this helper when displaying icons or cursors

## Testing
- `python3 -m pip install -r python_resource_editor/requirements.txt`
- `python3 -m compileall python_resource_editor/src`

------
https://chatgpt.com/codex/tasks/task_e_68533d2bcea88330be49a725aa924cb9